### PR TITLE
Optional matrix headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 - Better docs
 - Added DTD from Maoz & Graur (2017)
 - The DTD from Mannucci, Della Valle & Panagia is deprecated
+- Added `matrix_headers` setting to optionally remove headers from `qm-matrices` file
 
 1.1.0 (2019-04-22)
 ==================
@@ -34,7 +35,7 @@ Minor changes
 
 .. _`All v1.1.0 commits`: https://github.com/xuanxu/intergalactic/compare/v1.0.0...v1.1.0
 
-1.0.0 Mercedes Mollá Release - (2019-04-05) 
+1.0.0 Mercedes Mollá Release - (2019-04-05)
 ===========================================
 
 New nucleosynthesis method

--- a/src/intergalactic/model.py
+++ b/src/intergalactic/model.py
@@ -68,7 +68,7 @@ class Model:
                     imf_supernovas_II(m, self.initial_mass_function, self.context["binary_fraction"])
             )
 
-            np.savetxt(matrices_file, q, fmt="%15.10f", header=f"Q matrix for mass interval: [{m_sup}, {m_inf}]")
+            np.savetxt(matrices_file, q, fmt="%15.10f", header=self.__matrix_header(m_sup, m_inf))
             imf_sn_file.write(f"  {supernova_Ia_rates:.10f}  {supernova_II_rates:.10f}  {self.energies[i]:.10f}\n")
 
         matrices_file.close()
@@ -103,3 +103,9 @@ class Model:
             self.sn_Ia_rates.append(self.context["binary_fraction"] * newton_cotes(t_inf, t_sup, self.dtd))
 
         mass_intervals_file.close()
+
+    def __matrix_header(self, m_sup, m_inf):
+        if self.context["matrix_headers"] is True:
+            return f"Q matrix for mass interval: [{m_sup}, {m_inf}]"
+        else:
+            return ""

--- a/src/intergalactic/sample_input/params.yml
+++ b/src/intergalactic/sample_input/params.yml
@@ -10,7 +10,8 @@
 # total_time_steps            -> Total time steps for integration. Default value: 300
 # binary_fraction             -> Fraction of binary systems. Default value: 0.05
 # dtd_sn                      -> Delay time distribution to use for Supernovas (*). Default value: rpl
-# output_dir                  -> Name of the directory where results are written. Defaults to "results",
+# output_dir                  -> Name of the directory where results are written. Defaults to "results"
+# matrix_headers              -> Flag to include headers in the qm-matrices file. Default value: yes
 # expelled_elements_filename  -> Filename of ejected data. Defaults to an internal file with data for z=0.02 from
 #                                Gavilan et al, 2006, A&A, 450, 509 and Chieffi & Limongi, 2004, ApJ, 608, 405
 

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -21,7 +21,7 @@ default = {
     "binary_fraction": constants.BIN_FRACTION,
     "dtd_sn": "rlp",
     "output_dir": "results",
-    "matrix_headers": "yes",
+    "matrix_headers": True,
     "expelled_elements_filename": join(dirname(__file__), "sample_input", "expelled_elements")
 }
 

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -21,6 +21,7 @@ default = {
     "binary_fraction": constants.BIN_FRACTION,
     "dtd_sn": "rlp",
     "output_dir": "results",
+    "matrix_headers": "yes",
     "expelled_elements_filename": join(dirname(__file__), "sample_input", "expelled_elements")
 }
 


### PR DESCRIPTION
This PR adds a new setting `matrix_headers` to optionally remove headers from the `qm-matrices` file.