### PR TITLE
Two time deltas

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,3 +76,12 @@ The ``dtd_sn`` param in the config file can be set to use any of the available D
 :maoz: The DTD of Type Ia supernovae from Maoz & Graur (2017)
 :mdvp: DTD from Mannucci, Della Valle, Panagia 2006
 :castrillo: DTD of Type Ia supernovae from Castrillo et al. (2020)
+
+Integration step
+----------------
+
+By default integration steps are constant in `log(t)` but this behavior can be changed via the `integration_step` setting, that can take this values:
+
+:logt: Integration step is constant in `log(t)`, so it is smaller for short-lived stars and gradually increases when time increases (stellar mass decreases)
+:t:    Integration step is constant in `t`. Less efficient than log(t) but can be used to study specific intervals. Should be tuned with `total_time_steps` setting
+:two_steps_t: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored.

--- a/src/intergalactic/model.py
+++ b/src/intergalactic/model.py
@@ -94,8 +94,10 @@ class Model:
             self.explosive_nucleosynthesis_step_logt()
         elif self.integration_step == "t":
             self.explosive_nucleosynthesis_step_t()
+        elif self.integration_step == "two_steps_t":
+            self.explosive_nucleosynthesis_two_steps_t()
         else:
-            raise ValueError("Invalid value for integration step. Should be one of: [logt, t]")
+            raise ValueError("Invalid value for integration step. Should be one of: [logt, t, two_steps_t]")
 
     def explosive_nucleosynthesis_step_logt(self):
         t_ini = stellar_lifetime(min(self.m_max, max_mass_allowed(self.z)), self.z)

--- a/src/intergalactic/model.py
+++ b/src/intergalactic/model.py
@@ -128,7 +128,7 @@ class Model:
 
     def explosive_nucleosynthesis_step_t(self):
         t_ini = stellar_lifetime(self.m_max, self.z)
-        t_end = constants.TOTAL_TIME
+        t_end = min(stellar_lifetime(self.m_min, self.z), constants.TOTAL_TIME)
 
         delta_t = (t_end - t_ini) / self.total_time_steps
 

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -31,7 +31,7 @@ valid_values = {
     "imf": ["salpeter", "starburst", "chabrier", "ferrini", "kroupa", "miller_scalo", "maschberger"],
     "dtd_sn": ["rlp", "mdvp", "maoz", "castrillo"],
     "sol_ab": ["ag89", "gs98", "as05", "as09", "he10", "lo19"],
-    "integration_step": ["logt", "t"],
+    "integration_step": ["logt", "t", "two_steps_t"],
 }
 
 

--- a/src/intergalactic/tests/test_model.py
+++ b/src/intergalactic/tests/test_model.py
@@ -59,28 +59,46 @@ def test_model_run(mocker):
 def test_explosive_nucleosynthesis_with_logt_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
 
     model = Model({**settings.default, **{"integration_step": "logt"}})
     model.explosive_nucleosynthesis()
 
     Model.explosive_nucleosynthesis_step_logt.assert_called_once()
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_with_t_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
 
     model = Model({**settings.default, **{"integration_step": "t"}})
     model.explosive_nucleosynthesis()
 
     Model.explosive_nucleosynthesis_step_t.assert_called_once()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
+
+
+def test_explosive_nucleosynthesis_with_two_steps_t(mocker, deactivate_open_files):
+    mocker.spy(Model, "explosive_nucleosynthesis_step_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+
+    model = Model({**settings.default, **{"integration_step": "two_steps_t"}})
+    model.explosive_nucleosynthesis()
+
+    Model.explosive_nucleosynthesis_two_steps_t.assert_called_once()
+    Model.explosive_nucleosynthesis_step_t.assert_not_called()
+    Model.explosive_nucleosynthesis_step_logt.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_with_invalid_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
 
     model = Model({**settings.default, **{"integration_step": "t2"}})
     with pytest.raises(ValueError):
@@ -88,6 +106,7 @@ def test_explosive_nucleosynthesis_with_invalid_step(mocker, deactivate_open_fil
 
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_step_t(mocker, deactivate_open_files):
@@ -109,6 +128,18 @@ def test_explosive_nucleosynthesis_step_logt(mocker, deactivate_open_files):
     assert len(model.mass_intervals) == settings.default["total_time_steps"]
     assert len(model.energies) == settings.default["total_time_steps"]
     assert len(model.sn_Ia_rates) == settings.default["total_time_steps"]
+    mocked_file.assert_called_once_with(f"{settings.default['output_dir']}/mass_intervals", "w+")
+
+
+def test_explosive_nucleosynthesis_two_steps_t(mocker, deactivate_open_files):
+    mocked_file = deactivate_open_files
+    model = Model(settings.default)
+    model.explosive_nucleosynthesis_two_steps_t()
+
+    assert model.total_time_steps != settings.default["total_time_steps"]
+    assert len(model.mass_intervals) == model.total_time_steps
+    assert len(model.energies) == model.total_time_steps
+    assert len(model.sn_Ia_rates) == model.total_time_steps
     mocked_file.assert_called_once_with(f"{settings.default['output_dir']}/mass_intervals", "w+")
 
 


### PR DESCRIPTION
This PR adds a 2-interval integration option, where the integration step in time is:
- `Delta 1 = half the stellar lifetime of a 100 Msun star` if stars > 4 Msun
- `Delta 2 = 50 times Delta 1` if stars < 4 Msun
