### PR TITLE
Fixed number of steps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,12 @@ Changelog
 =========
 
 
-1.X.X (Unreleased)
+1.3.0 (Unreleased)
 ==================
 
 - Added dataset of solar abundances from Lodders et al. 2019
+- Added ``two_steps_t`` option for ``integration_step`` setting: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored
+- Added ``fixed_n_steps`` option for ``integration_step`` setting: The integration will take exactly the number of time steps specified in the next two settings (``integration_steps_stars_smaller_than_4Msun`` and ``integration_steps_stars_bigger_than_4Msun``)
 
 1.2.0 (2020-03-12)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Intergalactic reads a config file where several options can be set in yaml forma
         binary_fraction: 0.15   # rate of binary stars
         dtd_sn: rlp             # delay time distribution for supernovas
         output_dir: results     # Name of the directory where results are written.
-        integration_step: logt  # The integration step can be constant in t or in log(t)
+        integration_step: logt  # The integration step can be constant in t, constant in log(t), or custom.
         expelled_elements_filename: ejecta.txt  # Filename of ejected data.
 
 Intergalactic will use its internal default values for all params for which no values are provided.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,3 +76,12 @@ The ``dtd_sn`` param in the config file can be set to use any of the available D
 :maoz: The DTD of Type Ia supernovae from Maoz & Graur (2017)
 :mdvp: DTD from Mannucci, Della Valle, Panagia 2006
 :castrillo: DTD of Type Ia supernovae from Castrillo et al. (2020)
+
+Integration step
+----------------
+
+By default integration steps are constant in `log(t)` but this behavior can be changed via the `integration_step` setting, that can take this values:
+
+:logt: Integration step is constant in `log(t)`, so it is smaller for short-lived stars and gradually increases when time increases (stellar mass decreases)
+:t:    Integration step is constant in `t`. Less efficient than log(t) but can be used to study specific intervals. Should be tuned with `total_time_steps` setting
+:two_steps_t: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -84,4 +84,7 @@ By default integration steps are constant in `log(t)` but this behavior can be c
 
 :logt: Integration step is constant in `log(t)`, so it is smaller for short-lived stars and gradually increases when time increases (stellar mass decreases)
 :t:    Integration step is constant in `t`. Less efficient than log(t) but can be used to study specific intervals. Should be tuned with `total_time_steps` setting
-:two_steps_t: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored.
+:two_steps_t: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored
+:fixed_n_steps: The integration will take exactly the number of time steps specified in the next two settings (`integration_steps_stars_smaller_than_4Msun` and `integration_steps_stars_bigger_than_4Msun`)
+:integration_steps_stars_bigger_than_4Msun: number of integration time steps for m = 4Msun to m_max. This option is ignored unless `integration_step` value is `fixed_n_steps`
+:integration_steps_stars_smaller_than_4Msun: number of integration time steps for m = m_min to 4Msun. This option is ignored unless `integration_step` value is `fixed_n_steps`

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -86,5 +86,5 @@ By default integration steps are constant in `log(t)` but this behavior can be c
 :t:    Integration step is constant in `t`. Less efficient than log(t) but can be used to study specific intervals. Should be tuned with `total_time_steps` setting
 :two_steps_t: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored
 :fixed_n_steps: The integration will take exactly the number of time steps specified in the next two settings (`integration_steps_stars_smaller_than_4Msun` and `integration_steps_stars_bigger_than_4Msun`)
-:integration_steps_stars_bigger_than_4Msun: number of integration time steps for m = 4Msun to m_max. This option is ignored unless `integration_step` value is `fixed_n_steps`
-:integration_steps_stars_smaller_than_4Msun: number of integration time steps for m = m_min to 4Msun. This option is ignored unless `integration_step` value is `fixed_n_steps`
+:integration_steps_stars_bigger_than_4Msun: integer number of integration time steps for m = 4Msun to m_max. This option is ignored unless `integration_step` value is `fixed_n_steps`
+:integration_steps_stars_smaller_than_4Msun: integer number of integration time steps for m = m_min to 4Msun. This option is ignored unless `integration_step` value is `fixed_n_steps`

--- a/src/intergalactic/model.py
+++ b/src/intergalactic/model.py
@@ -96,8 +96,12 @@ class Model:
             self.explosive_nucleosynthesis_step_t()
         elif self.integration_step == "two_steps_t":
             self.explosive_nucleosynthesis_two_steps_t()
+        elif self.integration_step == "fixed_n_steps":
+            steps_small_stars = self.context["integration_steps_stars_smaller_than_4Msun"]
+            steps_massive_stars = self.context["integration_steps_stars_bigger_than_4Msun"]
+            self.explosive_nucleosynthesis_fixed_n_steps(steps_massive_stars, steps_small_stars)
         else:
-            raise ValueError("Invalid value for integration step. Should be one of: [logt, t, two_steps_t]")
+            raise ValueError("Invalid value for integration step. Should be one of: [logt, t, two_steps_t, fixed_n_steps]")
 
     def explosive_nucleosynthesis_step_logt(self):
         t_ini = stellar_lifetime(min(self.m_max, max_mass_allowed(self.z)), self.z)
@@ -185,6 +189,47 @@ class Model:
         for step in range(0, steps_with_delta_t_2):
             t_inf = t_ini_for_delta_2 + (delta_t_2 * step)
             t_sup = t_ini_for_delta_2 + (delta_t_2 * (step + 1))
+
+            m_inf = stellar_mass(t_sup, self.z)
+            m_sup = stellar_mass(t_inf, self.z)
+
+            mass_intervals_file.write('\n' + f'{m_sup:14.10f}  ' + f'{m_inf:14.10f}  ' + str(step + 1))
+
+            self.mass_intervals.append([m_inf, m_sup])
+            self.energies.append(total_energy_ejected(t_sup) - total_energy_ejected(t_inf))
+            self.sn_Ia_rates.append(self.context["binary_fraction"] * newton_cotes(t_inf, t_sup, self.dtd))
+
+        mass_intervals_file.close()
+
+    def explosive_nucleosynthesis_fixed_n_steps(self, n_massive, n_small):
+        t_ini = stellar_lifetime(self.m_max, self.z)
+        t_limit_massive = stellar_lifetime(4.0, self.z)
+        t_end = min(stellar_lifetime(self.m_min, self.z), constants.TOTAL_TIME)
+
+        delta_t_1 = (t_limit_massive - t_ini) / n_massive
+        delta_t_2 = (t_end - t_limit_massive) / n_small
+
+        self.total_time_steps = n_massive + n_small
+
+        mass_intervals_file = open(f"{self.context['output_dir']}/mass_intervals", "w+")
+        mass_intervals_file.write(" ".join([str(i) for i in [t_ini, t_end, n_massive, n_small, delta_t_1, delta_t_2]]))
+
+        for step in range(0, n_massive):
+            t_inf = t_ini + (delta_t_1 * step)
+            t_sup = t_ini + (delta_t_1 * (step + 1))
+
+            m_inf = stellar_mass(t_sup, self.z)
+            m_sup = stellar_mass(t_inf, self.z)
+
+            mass_intervals_file.write('\n' + f'{m_sup:14.10f}  ' + f'{m_inf:14.10f}  ' + str(step + 1))
+
+            self.mass_intervals.append([m_inf, m_sup])
+            self.energies.append(total_energy_ejected(t_sup) - total_energy_ejected(t_inf))
+            self.sn_Ia_rates.append(self.context["binary_fraction"] * newton_cotes(t_inf, t_sup, self.dtd))
+
+        for step in range(0, n_small):
+            t_inf = t_limit_massive + (delta_t_2 * step)
+            t_sup = t_limit_massive + (delta_t_2 * (step + 1))
 
             m_inf = stellar_mass(t_sup, self.z)
             m_sup = stellar_mass(t_inf, self.z)

--- a/src/intergalactic/model.py
+++ b/src/intergalactic/model.py
@@ -94,8 +94,10 @@ class Model:
             self.explosive_nucleosynthesis_step_logt()
         elif self.integration_step == "t":
             self.explosive_nucleosynthesis_step_t()
+        elif self.integration_step == "two_steps_t":
+            self.explosive_nucleosynthesis_two_steps_t()
         else:
-            raise ValueError("Invalid value for integration step. Should be one of: [logt, t]")
+            raise ValueError("Invalid value for integration step. Should be one of: [logt, t, two_steps_t]")
 
     def explosive_nucleosynthesis_step_logt(self):
         t_ini = stellar_lifetime(min(self.m_max, max_mass_allowed(self.z)), self.z)

--- a/src/intergalactic/model.py
+++ b/src/intergalactic/model.py
@@ -128,7 +128,7 @@ class Model:
 
     def explosive_nucleosynthesis_step_t(self):
         t_ini = stellar_lifetime(self.m_max, self.z)
-        t_end = constants.TOTAL_TIME
+        t_end = min(stellar_lifetime(self.m_min, self.z), constants.TOTAL_TIME)
 
         delta_t = (t_end - t_ini) / self.total_time_steps
 

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -31,7 +31,7 @@ valid_values = {
     "imf": ["salpeter", "starburst", "chabrier", "ferrini", "kroupa", "miller_scalo", "maschberger"],
     "dtd_sn": ["rlp", "mdvp", "maoz", "castrillo"],
     "sol_ab": ["ag89", "gs98", "as05", "as09", "he10", "lo19"],
-    "integration_step": ["logt", "t", "two_steps_t"],
+    "integration_step": ["logt", "t", "two_steps_t", "fixed_n_steps"],
 }
 
 

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -31,7 +31,7 @@ valid_values = {
     "imf": ["salpeter", "starburst", "chabrier", "ferrini", "kroupa", "miller_scalo", "maschberger"],
     "dtd_sn": ["rlp", "mdvp", "maoz", "castrillo"],
     "sol_ab": ["ag89", "gs98", "as05", "as09", "he10", "lo19"],
-    "integration_step": ["logt", "t"],
+    "integration_step": ["logt", "t", "two_steps_t"],
 }
 
 

--- a/src/intergalactic/tests/test_model.py
+++ b/src/intergalactic/tests/test_model.py
@@ -59,28 +59,46 @@ def test_model_run(mocker):
 def test_explosive_nucleosynthesis_with_logt_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
 
     model = Model({**settings.default, **{"integration_step": "logt"}})
     model.explosive_nucleosynthesis()
 
     Model.explosive_nucleosynthesis_step_logt.assert_called_once()
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_with_t_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
 
     model = Model({**settings.default, **{"integration_step": "t"}})
     model.explosive_nucleosynthesis()
 
     Model.explosive_nucleosynthesis_step_t.assert_called_once()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
+
+
+def test_explosive_nucleosynthesis_with_two_steps_t(mocker, deactivate_open_files):
+    mocker.spy(Model, "explosive_nucleosynthesis_step_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+
+    model = Model({**settings.default, **{"integration_step": "two_steps_t"}})
+    model.explosive_nucleosynthesis()
+
+    Model.explosive_nucleosynthesis_two_steps_t.assert_called_once()
+    Model.explosive_nucleosynthesis_step_t.assert_not_called()
+    Model.explosive_nucleosynthesis_step_logt.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_with_invalid_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
 
     model = Model({**settings.default, **{"integration_step": "t2"}})
     with pytest.raises(ValueError):
@@ -88,6 +106,7 @@ def test_explosive_nucleosynthesis_with_invalid_step(mocker, deactivate_open_fil
 
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_step_t(mocker, deactivate_open_files):
@@ -109,6 +128,18 @@ def test_explosive_nucleosynthesis_step_logt(mocker, deactivate_open_files):
     assert len(model.mass_intervals) == settings.default["total_time_steps"]
     assert len(model.energies) == settings.default["total_time_steps"]
     assert len(model.sn_Ia_rates) == settings.default["total_time_steps"]
+    mocked_file.assert_called_once_with(f"{settings.default['output_dir']}/mass_intervals", "w+")
+
+
+def test_explosive_nucleosynthesis_two_steps_t(mocker, deactivate_open_files):
+    mocked_file = deactivate_open_files
+    model = Model(settings.default)
+    model.explosive_nucleosynthesis_two_steps_t()
+
+    assert model.total_time_steps != settings.default["total_time_steps"]
+    assert len(model.mass_intervals) == model.total_time_steps
+    assert len(model.energies) == model.total_time_steps
+    assert len(model.sn_Ia_rates) == model.total_time_steps
     mocked_file.assert_called_once_with(f"{settings.default['output_dir']}/mass_intervals", "w+")
 
 

--- a/src/intergalactic/tests/test_model.py
+++ b/src/intergalactic/tests/test_model.py
@@ -60,6 +60,7 @@ def test_explosive_nucleosynthesis_with_logt_step(mocker, deactivate_open_files)
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
     mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_fixed_n_steps")
 
     model = Model({**settings.default, **{"integration_step": "logt"}})
     model.explosive_nucleosynthesis()
@@ -67,12 +68,14 @@ def test_explosive_nucleosynthesis_with_logt_step(mocker, deactivate_open_files)
     Model.explosive_nucleosynthesis_step_logt.assert_called_once()
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
     Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
+    Model.explosive_nucleosynthesis_fixed_n_steps.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_with_t_step(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
     mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_fixed_n_steps")
 
     model = Model({**settings.default, **{"integration_step": "t"}})
     model.explosive_nucleosynthesis()
@@ -80,17 +83,37 @@ def test_explosive_nucleosynthesis_with_t_step(mocker, deactivate_open_files):
     Model.explosive_nucleosynthesis_step_t.assert_called_once()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
     Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
+    Model.explosive_nucleosynthesis_fixed_n_steps.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_with_two_steps_t(mocker, deactivate_open_files):
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
     mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_fixed_n_steps")
 
     model = Model({**settings.default, **{"integration_step": "two_steps_t"}})
     model.explosive_nucleosynthesis()
 
     Model.explosive_nucleosynthesis_two_steps_t.assert_called_once()
+    Model.explosive_nucleosynthesis_step_t.assert_not_called()
+    Model.explosive_nucleosynthesis_step_logt.assert_not_called()
+    Model.explosive_nucleosynthesis_fixed_n_steps.assert_not_called()
+
+
+def test_explosive_nucleosynthesis_with_fixed_n_steps(mocker, deactivate_open_files):
+    mocker.spy(Model, "explosive_nucleosynthesis_step_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
+    mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_fixed_n_steps")
+
+    model = Model({**settings.default, **{"integration_step": "fixed_n_steps",
+                                          "integration_steps_stars_smaller_than_4Msun": 100,
+                                          "integration_steps_stars_bigger_than_4Msun": 200}})
+    model.explosive_nucleosynthesis()
+
+    Model.explosive_nucleosynthesis_fixed_n_steps.assert_called_once_with(model, 200, 100)
+    Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
 
@@ -99,6 +122,7 @@ def test_explosive_nucleosynthesis_with_invalid_step(mocker, deactivate_open_fil
     mocker.spy(Model, "explosive_nucleosynthesis_step_t")
     mocker.spy(Model, "explosive_nucleosynthesis_step_logt")
     mocker.spy(Model, "explosive_nucleosynthesis_two_steps_t")
+    mocker.spy(Model, "explosive_nucleosynthesis_fixed_n_steps")
 
     model = Model({**settings.default, **{"integration_step": "t2"}})
     with pytest.raises(ValueError):
@@ -107,6 +131,7 @@ def test_explosive_nucleosynthesis_with_invalid_step(mocker, deactivate_open_fil
     Model.explosive_nucleosynthesis_step_t.assert_not_called()
     Model.explosive_nucleosynthesis_step_logt.assert_not_called()
     Model.explosive_nucleosynthesis_two_steps_t.assert_not_called()
+    Model.explosive_nucleosynthesis_fixed_n_steps.assert_not_called()
 
 
 def test_explosive_nucleosynthesis_step_t(mocker, deactivate_open_files):
@@ -137,6 +162,18 @@ def test_explosive_nucleosynthesis_two_steps_t(mocker, deactivate_open_files):
     model.explosive_nucleosynthesis_two_steps_t()
 
     assert model.total_time_steps != settings.default["total_time_steps"]
+    assert len(model.mass_intervals) == model.total_time_steps
+    assert len(model.energies) == model.total_time_steps
+    assert len(model.sn_Ia_rates) == model.total_time_steps
+    mocked_file.assert_called_once_with(f"{settings.default['output_dir']}/mass_intervals", "w+")
+
+
+def test_explosive_nucleosynthesis_fixed_n_steps(mocker, deactivate_open_files):
+    mocked_file = deactivate_open_files
+    model = Model(settings.default)
+    model.explosive_nucleosynthesis_fixed_n_steps(150, 91)
+
+    assert model.total_time_steps == 150+91
     assert len(model.mass_intervals) == model.total_time_steps
     assert len(model.energies) == model.total_time_steps
     assert len(model.sn_Ia_rates) == model.total_time_steps


### PR DESCRIPTION
This PR adds a couple of options to have time integration using different time steps for stars with `m < 4Msun` and `m > 4 Msun`. 

The `integration_step:` setting will accept two new values: The different time steps can be calculated automatically using the `two_steps_t` option, or the user can specify a fixed number of steps for each integration interval with the `fixed_n_steps`option, and then set the values using two new settings:

*    a fixed number of time steps for massive stars (M* > 4Msun), specified with the `integration_steps_stars_bigger_than_4Msun` setting

 *   a fixed number of time steps for small stars (M* < 4Msun), specified with the `integration_steps_stars_smaller_than_4Msun` setting
