### PR TITLE
Add Delay Time Distribution for SN Ia from Greggio

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 1.3.0 (Unreleased)
 ==================
 
+- Added new DTD option: Greggio, L. 2005
 - Added dataset of solar abundances from Lodders et al. 2019
 - Added ``two_steps_t`` option for ``integration_step`` setting: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored
 - Added ``fixed_n_steps`` option for ``integration_step`` setting: The integration will take exactly the number of time steps specified in the next two settings (``integration_steps_stars_smaller_than_4Msun`` and ``integration_steps_stars_bigger_than_4Msun``)

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ The ``dtd_sn`` param in the config file can be set to use any of the available D
 :mdvp: DTD from Mannucci, Della Valle, Panagia 2006
 :maoz: DTD of Type Ia supernovae from Maoz & Graur (2017)
 :castrillo: DTD of Type Ia supernovae from Castrillo et al. (2020)
+:greggio: DTD of Type Ia supernovae from Greggio, L. (2005)
 
 Test suite
 ==========
@@ -181,3 +182,4 @@ Intergalactic is built upon a long list of previous works from different authors
 * *Ruiz-Lapuente, P., Canal, R.*, 2000, astro.ph..9312R
 * *Maoz, D. & Graur, O.* 2017, ApJ, 848, 25M
 * *Castrillo, A. et al* 2020, MNRAS (*in preparation*)
+* *Greggio, L.* 2005, A&A 441, 1055–1078

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,6 +76,7 @@ The ``dtd_sn`` param in the config file can be set to use any of the available D
 :maoz: The DTD of Type Ia supernovae from Maoz & Graur (2017)
 :mdvp: DTD from Mannucci, Della Valle, Panagia 2006
 :castrillo: DTD of Type Ia supernovae from Castrillo et al. (2020)
+:greggio: DTD of Type Ia supernovae from Greggio, L. (2005)
 
 Integration step
 ----------------

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -30,6 +30,7 @@ Intergalactic is built upon a long list of previous works from different authors
 * *Mannucci, Della Valle, Panagia*, 2006, MNRAS, 370, 773M
 * *Maoz, D. & Graur, O.* 2017, ApJ, 848, 25M
 * *Castrillo, A. et al* 2020, MNRAS
+* *Greggio, L.* 2005, A&A 441, 1055–1078
 
 License
 -------

--- a/src/intergalactic/dtds.py
+++ b/src/intergalactic/dtds.py
@@ -16,7 +16,8 @@ def select_dtd(option):
         "rlp": dtd_ruiz_lapuente,
         "mdvp": dtd_mannucci_della_valle_panagia,
         "maoz": dtd_maoz_graur,
-        "castrillo": dtd_castrillo
+        "castrillo": dtd_castrillo,
+        "greggio": dtd_greggio
     }
     return dtds[option]
 
@@ -88,3 +89,24 @@ def dtd_castrillo(t):
     rate = 0.012556  # [SN / Yr / M*]
 
     return rate * dtd
+
+
+def dtd_greggio(t):
+    """
+    Delay Time Distribution (DTD) from Laura Greggio, A&A 441, 1055–1078 (2005)
+
+    """
+    logt = math.log10(t) + 9
+    if logt < 7.5:
+        dtd = 0
+    elif 7.5 <= logt < 7.735:
+        dtd = (0.00215/(7.776-7.516)) * (logt-7-50)
+    elif 7.735 <= logt < 8.55:
+        dtd = 0.003335 * math.exp(((-0.5 * (logt-8.22))/0.47) ** 2)
+    elif 8.55 <= logt < 8.61:
+        dtd = 0.002618 - ((0.002618-0.001129)/(8.6398-8.55)) * (logt-8.55)
+    else:
+        dtd = math.pow(10, ((-1.0615 * logt) + 6))
+
+    # Normalization
+    return dtd * 0.524563739

--- a/src/intergalactic/dtds.py
+++ b/src/intergalactic/dtds.py
@@ -3,8 +3,11 @@ Delay Time Distributions
 
 Contains some predefined DTDs from different papers/authors:
 
-* Ruiz Lapuente
+* Ruiz Lapuente & Canal (2000)
 * Mannucci, Della Valle, Panagia (2006)
+* Maoz & Graur (2017)
+* Castrillo et al (2020)
+* Greggio, L. (2005)
 
 """
 

--- a/src/intergalactic/sample_input/params.yml
+++ b/src/intergalactic/sample_input/params.yml
@@ -44,6 +44,7 @@
 #            rlp  = DTD from Ruiz-Lapuente (default)
 #            maoz = DTD from Maoz & Graur 2017
 #            castrillo = DTD from Castrillo et al. 2020
+#            greggio = DTD from Greggio, L. 2005
 #          ]
 
 z: 0.02

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -29,7 +29,7 @@ default = {
 
 valid_values = {
     "imf": ["salpeter", "starburst", "chabrier", "ferrini", "kroupa", "miller_scalo", "maschberger"],
-    "dtd_sn": ["rlp", "mdvp", "maoz", "castrillo"],
+    "dtd_sn": ["rlp", "mdvp", "maoz", "castrillo", "greggio"],
     "sol_ab": ["ag89", "gs98", "as05", "as09", "he10", "lo19"],
     "integration_step": ["logt", "t", "two_steps_t", "fixed_n_steps"],
 }

--- a/src/intergalactic/tests/test_dtds.py
+++ b/src/intergalactic/tests/test_dtds.py
@@ -6,6 +6,7 @@ from intergalactic.dtds import dtd_ruiz_lapuente
 from intergalactic.dtds import dtd_mannucci_della_valle_panagia
 from intergalactic.dtds import dtd_maoz_graur
 from intergalactic.dtds import dtd_castrillo
+from intergalactic.dtds import dtd_greggio
 
 
 @pytest.fixture
@@ -22,7 +23,7 @@ def test_dtds_presence(available_dtds):
 
 
 def test_select_dtd(available_dtds):
-    dtds = [dtd_ruiz_lapuente, dtd_mannucci_della_valle_panagia, dtd_maoz_graur, dtd_castrillo]
+    dtds = [dtd_ruiz_lapuente, dtd_mannucci_della_valle_panagia, dtd_maoz_graur, dtd_castrillo, dtd_greggio]
 
     for i in range(len(available_dtds)):
         times = [0.001, 9.] + list(np.random.rand(5)) + list(np.random.rand(5) * 9)


### PR DESCRIPTION
This PR adds a new option for DTD: the DTD for Supernovae Ia from Greggio, L. 2005.

