### PR TITLE
Remove DTD

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 - Added dataset of solar abundances from Lodders et al. 2019
 - Added ``two_steps_t`` option for ``integration_step`` setting: The integration will use two time steps: [half the lifetime of a 100 solar masses star for the given metallicity] as time step for stars bigger than 4 solar masses, and 100 times that for less massive stars. If this option is selected the `total_time_steps` setting is ignored
 - Added ``fixed_n_steps`` option for ``integration_step`` setting: The integration will take exactly the number of time steps specified in the next two settings (``integration_steps_stars_smaller_than_4Msun`` and ``integration_steps_stars_bigger_than_4Msun``)
+- Removed DTD from *Mannucci, Della Valle, Panagia (2006)* (was deprecated in v1.2.0)
 
 1.2.0 (2020-03-12)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,6 @@ Delay Time Distributions
 The ``dtd_sn`` param in the config file can be set to use any of the available Delay Time Distributions for supernova rates from different papers/authors:
 
 :rlp: Supernova rates from Ruiz-Lapuente et al. 2000
-:mdvp: DTD from Mannucci, Della Valle, Panagia 2006
 :maoz: DTD of Type Ia supernovae from Maoz & Graur (2017)
 :castrillo: DTD of Type Ia supernovae from Castrillo et al. (2020)
 :greggio: DTD of Type Ia supernovae from Greggio, L. (2005)
@@ -178,7 +177,6 @@ Intergalactic is built upon a long list of previous works from different authors
 * *Mollá et al.*, 2017, MNRAS, 468, 305-318
 * *Gavilan, Mollá & Buell*, 2006, A&A, 450, 509
 * *Raiteri C.M., Villata M. & Navarro J.F.*, 1996, A&A 315, 105-115
-* *Mannucci, Della Valle, Panagia*, 2006, MNRAS, 370, 773M
 * *Ruiz-Lapuente, P., Canal, R.*, 2000, astro.ph..9312R
 * *Maoz, D. & Graur, O.* 2017, ApJ, 848, 25M
 * *Castrillo, A. et al* 2020, MNRAS (*in preparation*)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -74,7 +74,6 @@ The ``dtd_sn`` param in the config file can be set to use any of the available D
 
 :rlp: Supernova rates from Ruiz-Lapuente et al. 2000
 :maoz: The DTD of Type Ia supernovae from Maoz & Graur (2017)
-:mdvp: DTD from Mannucci, Della Valle, Panagia 2006
 :castrillo: DTD of Type Ia supernovae from Castrillo et al. (2020)
 :greggio: DTD of Type Ia supernovae from Greggio, L. (2005)
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -27,7 +27,6 @@ Intergalactic is built upon a long list of previous works from different authors
 * *Mollá et al*, 2017, MNRAS, 468, 305-318
 * *Gavilan, Mollá & Buell*, 2006, A&A, 450, 509
 * *Raiteri C.M., Villata M. & Navarro J.F.*, 1996, A&A 315, 105-115
-* *Mannucci, Della Valle, Panagia*, 2006, MNRAS, 370, 773M
 * *Maoz, D. & Graur, O.* 2017, ApJ, 848, 25M
 * *Castrillo, A. et al* 2020, MNRAS
 * *Greggio, L.* 2005, A&A 441, 1055–1078

--- a/src/intergalactic/dtds.py
+++ b/src/intergalactic/dtds.py
@@ -4,7 +4,6 @@ Delay Time Distributions
 Contains some predefined DTDs from different papers/authors:
 
 * Ruiz Lapuente & Canal (2000)
-* Mannucci, Della Valle, Panagia (2006)
 * Maoz & Graur (2017)
 * Castrillo et al (2020)
 * Greggio, L. (2005)
@@ -17,7 +16,6 @@ import math
 def select_dtd(option):
     dtds = {
         "rlp": dtd_ruiz_lapuente,
-        "mdvp": dtd_mannucci_della_valle_panagia,
         "maoz": dtd_maoz_graur,
         "castrillo": dtd_castrillo,
         "greggio": dtd_greggio
@@ -49,23 +47,6 @@ def dtd_ruiz_lapuente(t):
     rate = 0.2440759  # [SN / Yr / M*]
 
     return rate * dtd
-
-
-def dtd_mannucci_della_valle_panagia(t):
-    """
-    Delay Time Distribution (DTD) from Mannucci, Della Valle, Panagia (2006)
-
-    """
-    if t <= 0:
-        return 0.0
-
-    logt = math.log10(t) + 9
-    if logt <= 7.93:
-        logDTD = 1.4 - 50.0 * (logt - 7.7)**2
-    else:
-        logDTD = -0.8 - 0.9 * (logt - 8.7)**2
-
-    return math.pow(10, logDTD)
 
 
 def dtd_maoz_graur(t):

--- a/src/intergalactic/sample_input/params.yml
+++ b/src/intergalactic/sample_input/params.yml
@@ -40,7 +40,6 @@
 #          ]
 
 # dtd_sn = [
-#            mdvp = DTD from Mannucci, Della Valle, Panagia 2006
 #            rlp  = DTD from Ruiz-Lapuente (default)
 #            maoz = DTD from Maoz & Graur 2017
 #            castrillo = DTD from Castrillo et al. 2020

--- a/src/intergalactic/settings.py
+++ b/src/intergalactic/settings.py
@@ -29,7 +29,7 @@ default = {
 
 valid_values = {
     "imf": ["salpeter", "starburst", "chabrier", "ferrini", "kroupa", "miller_scalo", "maschberger"],
-    "dtd_sn": ["rlp", "mdvp", "maoz", "castrillo", "greggio"],
+    "dtd_sn": ["rlp", "maoz", "castrillo", "greggio"],
     "sol_ab": ["ag89", "gs98", "as05", "as09", "he10", "lo19"],
     "integration_step": ["logt", "t", "two_steps_t", "fixed_n_steps"],
 }
@@ -60,9 +60,6 @@ def validate(params):
 
 def deprecation_warnings(params):
     deprecation_warnings = []
-
-    if params["dtd_sn"] == "mdvp":
-        deprecation_warnings.append("The DTD from Mannucci, Della Valle, Panagia is deprecated. It'll be removed in the next version.")
 
     if deprecation_warnings:
         print("*** Deprecations Warning ***")

--- a/src/intergalactic/tests/test_dtds.py
+++ b/src/intergalactic/tests/test_dtds.py
@@ -3,7 +3,6 @@ import numpy as np
 import intergalactic.settings as settings
 from intergalactic.dtds import select_dtd
 from intergalactic.dtds import dtd_ruiz_lapuente
-from intergalactic.dtds import dtd_mannucci_della_valle_panagia
 from intergalactic.dtds import dtd_maoz_graur
 from intergalactic.dtds import dtd_castrillo
 from intergalactic.dtds import dtd_greggio
@@ -23,7 +22,7 @@ def test_dtds_presence(available_dtds):
 
 
 def test_select_dtd(available_dtds):
-    dtds = [dtd_ruiz_lapuente, dtd_mannucci_della_valle_panagia, dtd_maoz_graur, dtd_castrillo, dtd_greggio]
+    dtds = [dtd_ruiz_lapuente, dtd_maoz_graur, dtd_castrillo, dtd_greggio]
 
     for i in range(len(available_dtds)):
         times = [0.001, 9.] + list(np.random.rand(5)) + list(np.random.rand(5) * 9)
@@ -34,5 +33,4 @@ def test_select_dtd(available_dtds):
 def test_no_negative_time_values():
     t = -1
     assert dtd_ruiz_lapuente(t) == 0.0
-    assert dtd_mannucci_della_valle_panagia(t) == 0.0
     assert dtd_maoz_graur(t) == 0.0

--- a/src/intergalactic/tests/test_model.py
+++ b/src/intergalactic/tests/test_model.py
@@ -19,7 +19,7 @@ def test_model_initialization():
         "m_min": 1.1,
         "m_max": 42.0,
         "total_time_steps": 250,
-        "dtd_sn": "mdvp"
+        "dtd_sn": "greggio"
     }
     validated_params = settings.validate(params)
     model = Model(validated_params)
@@ -31,7 +31,7 @@ def test_model_initialization():
     assert model.energies == []
     assert model.sn_Ia_rates == []
     assert model.z == params["z"]
-    assert model.dtd == dtds.dtd_mannucci_della_valle_panagia
+    assert model.dtd == dtds.dtd_greggio
     assert model.m_min == params["m_min"]
     assert model.m_max == params["m_max"]
     assert model.total_time_steps == params["total_time_steps"]

--- a/src/intergalactic/tests/test_settings.py
+++ b/src/intergalactic/tests/test_settings.py
@@ -16,7 +16,7 @@ def test_validate_with_valid_values():
         "z": 0.033,
         "imf": "miller_scalo",
         "imf_m_low": 0.3,
-        "dtd_sn": "mdvp",
+        "dtd_sn": "castrillo",
         "sol_ab": "ag89",
         "m_max": 40.0,
         "output_dir": "testing"


### PR DESCRIPTION
The `Mannucci, Della Valle, Panagia` DTD was deprecated in v1.2.0.
This PR removes it from `intergalactic` 